### PR TITLE
Add info on a rust compile issue to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 2. Go to root folder where you see `default.nix` and run `nix-shell` (It takes a lot of time just for the first time.)
 3. Go to tests folder and run `npm i`
 4. In the tests folder run `npm test`
+In case you run into compile errors - esp. relating to lazy_static, you may have to manually set the toolchain to the rust nightly release channel
+5. From the tests folder in nix-shell run `rustup toolchain install nightly`
+6. And then `rustup override set nightly` and then run `npm test` again.
 ___________
 
 ### This video of Holochain-in-Action can help for better understanding:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 2. Go to root folder where you see `default.nix` and run `nix-shell` (It takes a lot of time just for the first time.)
 3. Go to tests folder and run `npm i`
 4. In the tests folder run `npm test`
+
 In case you run into compile errors - esp. relating to lazy_static, you may have to manually set the toolchain to the rust nightly release channel
+
 5. From the tests folder in nix-shell run `rustup toolchain install nightly`
 6. And then `rustup override set nightly` and then run `npm test` again.
 ___________


### PR DESCRIPTION
Some of the dependencies do not compile on the stable release of the rust toolchain mostly because they are using experimental or non-standardized features that are only available in nightly releases. I faced this issue so I added information to that effect.

If this is not the right spot for this info please place it in the spot or let me know where I should add it.